### PR TITLE
Suggestions on the vignettes

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,4 @@
 ^codecov\.yml$
 ^docs$
 ^pkgdown$
+^\.Rprofile$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,6 +9,10 @@ Authors@R:
 Description: This package contains diverse functionality to extend the usage
     of the iSEE package, including additional classes for the panels or modes
     facilitating the analysis of differential expression results.
+    This package does not perform differential expression. Instead, it provides
+    methods to embed precomputed differential expression results in a
+    SummarizedExperiment object, in a manner that is compatible with interactive
+    visualisation in iSEE applications.
 License: Artistic-2.0
 URL: https://github.com/iSEE/iSEEde
 BugReports: https://support.bioconductor.org/t/iSEEde

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,7 +13,8 @@ License: Artistic-2.0
 URL: https://github.com/iSEE/iSEEde
 BugReports: https://support.bioconductor.org/t/iSEEde
 biocViews: Software,
-    Infrastructure
+    Infrastructure,
+    DifferentialExpression
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,7 +34,7 @@ Suggests:
     org.Hs.eg.db,
     RefManageR,
     rmarkdown,
-    scater,
+    scuttle,
     sessioninfo,
     statmod,
     testthat (>= 3.0.0)

--- a/R/AllGenerics.R
+++ b/R/AllGenerics.R
@@ -1,63 +1,63 @@
 #' Generics for Differential Expression Results
-#' 
+#'
 #' An overview of the generics for accessing common pieces of information in differential expression results.
-#' 
+#'
 #' @section Definitions:
 #' \itemize{
 #' \item `pValue(x)` returns a numeric vector of raw p-values.
 #' \item `log2FoldChange(x)` returns a numeric vector of log2-fold-change values.
 #' \item `averageLog2(x)` returns a numeric vector of average log2-expression values.
 #' }
-#' 
+#'
 #' @docType methods
 #' @aliases pValue log2FoldChange averageLog2
 #' @name de-generics
 #' @author Kevin Rue-Albrecht
-#' 
-#' @examples 
+#'
+#' @examples
 #' showMethods(pValue)
 #' showMethods(log2FoldChange)
 #' showMethods(averageLog2)
 NULL
 
 setGeneric(
-  "pValue",
-  function(x) standardGeneric("pValue")
+    "pValue",
+    function(x) standardGeneric("pValue")
 )
 
 setGeneric(
-  "log2FoldChange",
-  function(x) standardGeneric("log2FoldChange")
+    "log2FoldChange",
+    function(x) standardGeneric("log2FoldChange")
 )
 
 setGeneric(
-  "averageLog2",
-  function(x) standardGeneric("averageLog2")
+    "averageLog2",
+    function(x) standardGeneric("averageLog2")
 )
 
 #' Generics for Embbedding Results into a SummarizedExperiment Object
-#' 
+#'
 #' An overview of the generics for embedding results into a \linkS4class{SummarizedExperiment} object, in a format compatible with \pkg{iSEEde}.
-#' 
+#'
 #' @section Definitions:
 #' \itemize{
 #' \item `embedResults(x, se, name, ...)` embeds the results `x` in the \linkS4class{SummarizedExperiment} `se`.
 #' }
-#' 
+#'
 #' @docType methods
 #' @aliases embedResults
 #' @name utils-SummarizedExperiment
 #' @author Kevin Rue-Albrecht
-#' 
-#' @examples 
+#'
+#' @examples
 #' embedResultsMethods
-#' 
+#'
 #' showMethods(embedResults)
 NULL
 
 #' @rdname utils-SummarizedExperiment
 #' @aliases embedResults,ANY-method
 setGeneric(
-  "embedResults",
-  function(x, se, name, ...) standardGeneric("embedResults")
+    "embedResults",
+    function(x, se, name, ...) standardGeneric("embedResults")
 )

--- a/R/MAPlot-class.R
+++ b/R/MAPlot-class.R
@@ -1,8 +1,8 @@
 #' The MAPlot class
-#' 
+#'
 #' The MAPlot is a \linkS4class{RowDataPlot} subclass that is dedicated to creating a volcano plot.
 #' It retrieves the log-fold change and p-value from and creates a row-based plot where each point represents a feature.
-#' 
+#'
 #' @docType methods
 #' @aliases MAPlot MAPlot-class
 #' initialize,MAPlot-method
@@ -13,10 +13,10 @@
 #' .generateDotPlotData,MAPlot-method
 #' .panelColor,MAPlot-method
 #' .refineParameters,MAPlot-method
-#' 
+#'
 #' @name MAPlot-class
-#' 
-#' @examples 
+#'
+#' @examples
 #' x <- MAPlot()
 #' x[["ContrastName"]]
 #' x[["ContrastName"]] <- "treated vs control"
@@ -24,8 +24,10 @@ NULL
 
 #' @export
 #' @importClassesFrom iSEE RowDotPlot
-setClass("MAPlot", contains="RowDotPlot",
-         slots = c(ContrastName = "character"))
+setClass("MAPlot",
+    contains = "RowDotPlot",
+    slots = c(ContrastName = "character")
+)
 
 #' @export
 #' @importMethodsFrom iSEE .fullName
@@ -38,22 +40,21 @@ setMethod(".panelColor", "MAPlot", function(x) "#DEAE10")
 #' @export
 #' @importMethodsFrom methods initialize
 #' @importFrom methods callNextMethod
-setMethod("initialize", "MAPlot", function(.Object, ContrastName=NA_character_, ...)
-{
-  args <- list(ContrastName=ContrastName, ...)
-  
-  do.call(callNextMethod, c(list(.Object), args))
+setMethod("initialize", "MAPlot", function(.Object, ContrastName = NA_character_, ...) {
+    args <- list(ContrastName = ContrastName, ...)
+
+    do.call(callNextMethod, c(list(.Object), args))
 })
 
 #' @export
 #' @importFrom methods new
 MAPlot <- function(...) {
-  new("MAPlot", ...)
+    new("MAPlot", ...)
 }
 
 #' @importFrom S4Vectors setValidity2
 setValidity2("MAPlot", function(object) {
-  return(TRUE)
+    return(TRUE)
 })
 
 #' @export
@@ -62,15 +63,15 @@ setValidity2("MAPlot", function(object) {
 #' @importFrom methods callNextMethod
 #' @importFrom SummarizedExperiment rowData
 setMethod(".cacheCommonInfo", "MAPlot", function(x, se) {
-  if (!is.null(.getCachedCommonInfo(se, "MAPlot"))) {
-    return(se)
-  }
-  
-  se <- callNextMethod()
-  
-  contrast_names <- names(rowData(se)[["iSEEde"]])
-  
-  .setCachedCommonInfo(se, "MAPlot", valid.contrast.names = contrast_names)
+    if (!is.null(.getCachedCommonInfo(se, "MAPlot"))) {
+        return(se)
+    }
+
+    se <- callNextMethod()
+
+    contrast_names <- names(rowData(se)[["iSEEde"]])
+
+    .setCachedCommonInfo(se, "MAPlot", valid.contrast.names = contrast_names)
 })
 
 #' @export
@@ -78,15 +79,15 @@ setMethod(".cacheCommonInfo", "MAPlot", function(x, se) {
 #' @importFrom iSEE .getCachedCommonInfo .replaceMissingWithFirst
 #' @importFrom methods callNextMethod
 setMethod(".refineParameters", "MAPlot", function(x, se) {
-  x <- callNextMethod() # Trigger warnings from base classes.
-  if (is.null(x)) {
-    return(NULL)
-  }
-  
-  contrast_names <- .getCachedCommonInfo(se, "MAPlot")$valid.contrast.names
-  x <- .replaceMissingWithFirst(x, .contrastName, contrast_names)
-  
-  x
+    x <- callNextMethod() # Trigger warnings from base classes.
+    if (is.null(x)) {
+        return(NULL)
+    }
+
+    contrast_names <- .getCachedCommonInfo(se, "MAPlot")$valid.contrast.names
+    x <- .replaceMissingWithFirst(x, .contrastName, contrast_names)
+
+    x
 })
 
 #' @export
@@ -99,9 +100,10 @@ setMethod(".createObservers", "MAPlot", function(x, se, input, session, pObjects
     plot_name <- .getEncodedName(x)
 
     .createProtectedParameterObservers(plot_name,
-        fields=c(.contrastName),
-        input=input, pObjects=pObjects, rObjects=rObjects)
-    
+        fields = c(.contrastName),
+        input = input, pObjects = pObjects, rObjects = rObjects
+    )
+
     invisible(NULL)
 })
 
@@ -112,59 +114,61 @@ setMethod(".createObservers", "MAPlot", function(x, se, input, session, pObjects
 #' @importFrom iSEE .addSpecificTour .getCachedCommonInfo .getEncodedName
 #' .selectInput.iSEE
 setMethod(".defineDataInterface", "MAPlot", function(x, se, select_info) {
-  plot_name <- .getEncodedName(x)
-  input_FUN <- function(field) paste0(plot_name, "_", field)
-  # nocov start
-  .addSpecificTour(class(x), .contrastName, function(plot_name) {
-    data.frame(
-      rbind(
-        c(
-          element=paste0("#", plot_name, "_", sprintf("%s + .selectize-control", .contrastName)),
-          intro="Here, we select the name of the contrast to visualise amongst the choice of differential expression results available."
+    plot_name <- .getEncodedName(x)
+    input_FUN <- function(field) paste0(plot_name, "_", field)
+    # nocov start
+    .addSpecificTour(class(x), .contrastName, function(plot_name) {
+        data.frame(
+            rbind(
+                c(
+                    element = paste0("#", plot_name, "_", sprintf("%s + .selectize-control", .contrastName)),
+                    intro = "Here, we select the name of the contrast to visualise amongst the choice of differential expression results available."
+                )
+            )
         )
-      )
+    })
+    # nocov end
+    cached <- .getCachedCommonInfo(se, "MAPlot")
+
+    extra_inputs <- list(
+        .selectInput.iSEE(x, .contrastName,
+            label = "Contrast:",
+            selected = x[[.contrastName]],
+            choices = cached$valid.contrast.names
+        )
     )
-  })
-  # nocov end
-  cached <- .getCachedCommonInfo(se, "MAPlot")
-  
-  extra_inputs <- list(
-    .selectInput.iSEE(x, .contrastName, 
-                      label="Contrast:",
-                      selected=x[[.contrastName]],
-                      choices=cached$valid.contrast.names)
-  )
-  
-  c(callNextMethod(), 
-    list(hr()), 
-    extra_inputs
-  )
+
+    c(
+        callNextMethod(),
+        list(hr()),
+        extra_inputs
+    )
 })
 
 #' @export
 #' @importMethodsFrom iSEE .generateDotPlotData
 #' @importFrom iSEE .textEval
 setMethod(".generateDotPlotData", "MAPlot", function(x, envir) {
-  data_cmds <- list()
-  
-  y_lab <- "logFC"
-  
-  data_cmds[["edgeR"]] <- sprintf("de_table <- rowData(se)[['iSEEde']][['%s']]", x[[.contrastName]])
-  
-  # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
-  data_cmds[["y"]] <- c(
-    "plot.data <- data.frame(row.names=rownames(se))",
-    "plot.data$Y <- iSEEde::log2FoldChange(de_table)"
-  )
-  
-  # Prepare X-axis data.
-  x_lab <- "AveExpr"
-  data_cmds[["x"]] <- "plot.data$X <- iSEEde::averageLog2(de_table)"
-  
-  plot_title <- x[[.contrastName]]
-  
-  data_cmds <- unlist(data_cmds)
-  .textEval(data_cmds, envir)
-  
-  list(commands=data_cmds, labels=list(title=plot_title, X=x_lab, Y=y_lab))
+    data_cmds <- list()
+
+    y_lab <- "logFC"
+
+    data_cmds[["edgeR"]] <- sprintf("de_table <- rowData(se)[['iSEEde']][['%s']]", x[[.contrastName]])
+
+    # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
+    data_cmds[["y"]] <- c(
+        "plot.data <- data.frame(row.names=rownames(se))",
+        "plot.data$Y <- iSEEde::log2FoldChange(de_table)"
+    )
+
+    # Prepare X-axis data.
+    x_lab <- "AveExpr"
+    data_cmds[["x"]] <- "plot.data$X <- iSEEde::averageLog2(de_table)"
+
+    plot_title <- x[[.contrastName]]
+
+    data_cmds <- unlist(data_cmds)
+    .textEval(data_cmds, envir)
+
+    list(commands = data_cmds, labels = list(title = plot_title, X = x_lab, Y = y_lab))
 })

--- a/R/VolcanoPlot-class.R
+++ b/R/VolcanoPlot-class.R
@@ -1,8 +1,8 @@
 #' The VolcanoPlot class
-#' 
+#'
 #' The VolcanoPlot is a \linkS4class{RowDataPlot} subclass that is dedicated to creating a volcano plot.
 #' It retrieves the log-fold change and p-value from and creates a row-based plot where each point represents a feature.
-#' 
+#'
 #' @docType methods
 #' @aliases VolcanoPlot VolcanoPlot-class
 #' initialize,VolcanoPlot-method
@@ -13,10 +13,10 @@
 #' .generateDotPlotData,VolcanoPlot-method
 #' .panelColor,VolcanoPlot-method
 #' .refineParameters,VolcanoPlot-method
-#' 
+#'
 #' @name VolcanoPlot-class
-#' 
-#' @examples 
+#'
+#' @examples
 #' x <- VolcanoPlot()
 #' x[["ContrastName"]]
 #' x[["ContrastName"]] <- "treated vs control"
@@ -24,8 +24,10 @@ NULL
 
 #' @export
 #' @importClassesFrom iSEE RowDotPlot
-setClass("VolcanoPlot", contains="RowDotPlot",
-         slots = c(ContrastName = "character"))
+setClass("VolcanoPlot",
+    contains = "RowDotPlot",
+    slots = c(ContrastName = "character")
+)
 
 #' @export
 #' @importMethodsFrom iSEE .fullName
@@ -39,22 +41,21 @@ setMethod(".panelColor", "VolcanoPlot", function(x) "#DEAE10")
 #' @importMethodsFrom methods initialize
 #' @importFrom methods callNextMethod
 setMethod("initialize", "VolcanoPlot", function(.Object,
-    ContrastName=NA_character_, ...)
-{
-  args <- list(ContrastName=ContrastName, ...)
-  
-  do.call(callNextMethod, c(list(.Object), args))
+                                                ContrastName = NA_character_, ...) {
+    args <- list(ContrastName = ContrastName, ...)
+
+    do.call(callNextMethod, c(list(.Object), args))
 })
 
 #' @export
 #' @importFrom methods new
 VolcanoPlot <- function(...) {
-  new("VolcanoPlot", ...)
+    new("VolcanoPlot", ...)
 }
 
 #' @importFrom S4Vectors setValidity2
 setValidity2("VolcanoPlot", function(object) {
-  return(TRUE)
+    return(TRUE)
 })
 
 #' @export
@@ -63,15 +64,15 @@ setValidity2("VolcanoPlot", function(object) {
 #' @importFrom methods callNextMethod
 #' @importFrom SummarizedExperiment rowData
 setMethod(".cacheCommonInfo", "VolcanoPlot", function(x, se) {
-  if (!is.null(.getCachedCommonInfo(se, "VolcanoPlot"))) {
-    return(se)
-  }
-  
-  se <- callNextMethod()
-  
-  contrast_names <- colnames(rowData(se)[["iSEEde"]])
+    if (!is.null(.getCachedCommonInfo(se, "VolcanoPlot"))) {
+        return(se)
+    }
 
-  .setCachedCommonInfo(se, "VolcanoPlot", valid.contrast.names = contrast_names)
+    se <- callNextMethod()
+
+    contrast_names <- colnames(rowData(se)[["iSEEde"]])
+
+    .setCachedCommonInfo(se, "VolcanoPlot", valid.contrast.names = contrast_names)
 })
 
 #' @export
@@ -79,15 +80,15 @@ setMethod(".cacheCommonInfo", "VolcanoPlot", function(x, se) {
 #' @importFrom iSEE .getCachedCommonInfo .replaceMissingWithFirst
 #' @importFrom methods callNextMethod
 setMethod(".refineParameters", "VolcanoPlot", function(x, se) {
-  x <- callNextMethod() # Trigger warnings from base classes.
-  if (is.null(x)) {
-    return(NULL)
-  }
-  
-  contrast_names <- .getCachedCommonInfo(se, "VolcanoPlot")$valid.contrast.names
-  x <- .replaceMissingWithFirst(x, .contrastName, contrast_names)
-  
-  x
+    x <- callNextMethod() # Trigger warnings from base classes.
+    if (is.null(x)) {
+        return(NULL)
+    }
+
+    contrast_names <- .getCachedCommonInfo(se, "VolcanoPlot")$valid.contrast.names
+    x <- .replaceMissingWithFirst(x, .contrastName, contrast_names)
+
+    x
 })
 
 #' @export
@@ -100,9 +101,10 @@ setMethod(".createObservers", "VolcanoPlot", function(x, se, input, session, pOb
     plot_name <- .getEncodedName(x)
 
     .createProtectedParameterObservers(plot_name,
-        fields=c(.contrastName),
-        input=input, pObjects=pObjects, rObjects=rObjects)
-    
+        fields = c(.contrastName),
+        input = input, pObjects = pObjects, rObjects = rObjects
+    )
+
     invisible(NULL)
 })
 
@@ -113,59 +115,61 @@ setMethod(".createObservers", "VolcanoPlot", function(x, se, input, session, pOb
 #' @importFrom iSEE .addSpecificTour .getCachedCommonInfo .getEncodedName
 #' .selectInput.iSEE
 setMethod(".defineDataInterface", "VolcanoPlot", function(x, se, select_info) {
-  plot_name <- .getEncodedName(x)
-  input_FUN <- function(field) paste0(plot_name, "_", field)
-  # nocov start
-  .addSpecificTour(class(x), .contrastName, function(plot_name) {
-    data.frame(
-      rbind(
-        c(
-          element=paste0("#", plot_name, "_", sprintf("%s + .selectize-control", .contrastName)),
-          intro="Here, we select the name of the contrast to visualise amongst the choice of differential expression results available."
+    plot_name <- .getEncodedName(x)
+    input_FUN <- function(field) paste0(plot_name, "_", field)
+    # nocov start
+    .addSpecificTour(class(x), .contrastName, function(plot_name) {
+        data.frame(
+            rbind(
+                c(
+                    element = paste0("#", plot_name, "_", sprintf("%s + .selectize-control", .contrastName)),
+                    intro = "Here, we select the name of the contrast to visualise amongst the choice of differential expression results available."
+                )
+            )
         )
-      )
+    })
+    # nocov end
+    cached <- .getCachedCommonInfo(se, "VolcanoPlot")
+
+    extra_inputs <- list(
+        .selectInput.iSEE(x, .contrastName,
+            label = "Contrast:",
+            selected = x[[.contrastName]],
+            choices = cached$valid.contrast.names
+        )
     )
-  })
-  # nocov end
-  cached <- .getCachedCommonInfo(se, "VolcanoPlot")
-  
-  extra_inputs <- list(
-    .selectInput.iSEE(x, .contrastName, 
-                      label="Contrast:",
-                      selected=x[[.contrastName]],
-                      choices=cached$valid.contrast.names)
-  )
-  
-  c(callNextMethod(), 
-    list(hr()), 
-    extra_inputs
-  )
+
+    c(
+        callNextMethod(),
+        list(hr()),
+        extra_inputs
+    )
 })
 
 #' @export
 #' @importMethodsFrom iSEE .generateDotPlotData
 #' @importFrom iSEE .textEval
 setMethod(".generateDotPlotData", "VolcanoPlot", function(x, envir) {
-  data_cmds <- list()
-  
-  y_lab <- "-log10(P.Value)"
-  
-  data_cmds[["edgeR"]] <- sprintf("de_table <- rowData(se)[['iSEEde']][['%s']]", x[[.contrastName]])
-  
-  # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
-  data_cmds[["y"]] <- c(
-      "plot.data <- data.frame(row.names=rownames(se))",
-      "plot.data$Y <- -log10(iSEEde::pValue(de_table))"
-  )
-  
-  # Prepare X-axis data.
-  x_lab <- "logFC"
-  data_cmds[["x"]] <- "plot.data$X <- iSEEde::log2FoldChange(de_table)"
-  
-  plot_title <- x[[.contrastName]]
-  
-  data_cmds <- unlist(data_cmds)
-  .textEval(data_cmds, envir)
-  
-  list(commands=data_cmds, labels=list(title=plot_title, X=x_lab, Y=y_lab))
+    data_cmds <- list()
+
+    y_lab <- "-log10(P.Value)"
+
+    data_cmds[["edgeR"]] <- sprintf("de_table <- rowData(se)[['iSEEde']][['%s']]", x[[.contrastName]])
+
+    # NOTE: deparse() automatically adds quotes, AND protects against existing quotes/escapes.
+    data_cmds[["y"]] <- c(
+        "plot.data <- data.frame(row.names=rownames(se))",
+        "plot.data$Y <- -log10(iSEEde::pValue(de_table))"
+    )
+
+    # Prepare X-axis data.
+    x_lab <- "logFC"
+    data_cmds[["x"]] <- "plot.data$X <- iSEEde::log2FoldChange(de_table)"
+
+    plot_title <- x[[.contrastName]]
+
+    data_cmds <- unlist(data_cmds)
+    .textEval(data_cmds, envir)
+
+    list(commands = data_cmds, labels = list(title = plot_title, X = x_lab, Y = y_lab))
 })

--- a/R/iSEEDESeq2-class.R
+++ b/R/iSEEDESeq2-class.R
@@ -1,18 +1,18 @@
 #' The iSEEDESeq2Results class
-#' 
+#'
 #' The `iSEEDESeq2Results` class is used to provide an common interface to differential expression results produced by the \pkg{limma} package.
 #' It provides methods to access common differential expression statistics (e.g., log2 fold-change, p-value, log2 average abundance).
-#' 
+#'
 #' This class inherits all its slots directly from its parent class \linkS4class{DataFrame}.
-#' 
+#'
 #' @section Constructor:
 #' \code{iSEEDESeq2Results(data, row.names = rownames(data))} creates an instance of a `iSEEDESeq2Results` class, with:
-#' 
+#'
 #' \describe{
 #' \item{`data`}{A `data.frame` produced by `DESeq2::results()` or `DESeq2::lfcShrink()`.}
 #' \item{`row.names`}{The character vector of rownames for the \linkS4class{SummarizedExperiment} object in which the object is to be embedded. Must be a superset of `rownames(data)`.}
 #' }
-#' 
+#'
 #' @section Supported methods:
 #' \itemize{
 #' \item `embedResults(x, se, name, ...)` embeds `x` in the column `name` of `rowData(se)[["iSEEde"]]`.
@@ -20,9 +20,9 @@
 #' \item `log2FoldChange(x)` returns the vector of log2-fold-change values.
 #' \item `averageLog2(x)` returns the vector of average log2-expression values.
 #' }
-#' 
+#'
 #' @author Kevin Rue-Albrecht
-#' 
+#'
 #' @docType methods
 #' @name iSEEDESeq2Results-class
 #' @aliases
@@ -33,42 +33,42 @@
 #' averageLog2,iSEEDESeq2Results-method
 #' embedResults,iSEEDESeq2Results-method
 #' embedResults,DESeqResults-method
-#' 
+#'
 #' @examples
 #' library(DESeq2)
-#' 
+#'
 #' ##
 #' # From DESeq2::DESeq() ----
 #' ##
-#' 
-#' cnts <- matrix(rnbinom(n=1000, mu=100, size=1/0.5), ncol=10)
-#' rownames(cnts) <- paste("Gene",1:100)
-#' cond <- factor(rep(1:2, each=5))
-#' 
+#'
+#' cnts <- matrix(rnbinom(n = 1000, mu = 100, size = 1 / 0.5), ncol = 10)
+#' rownames(cnts) <- paste("Gene", 1:100)
+#' cond <- factor(rep(1:2, each = 5))
+#'
 #' # object construction
-#' dds <- DESeqDataSetFromMatrix(cnts, DataFrame(cond), ~ cond)
-#' 
+#' dds <- DESeqDataSetFromMatrix(cnts, DataFrame(cond), ~cond)
+#'
 #' # standard analysis
 #' dds <- DESeq(dds)
 #' res <- results(dds)
 #' head(res)
-#' 
+#'
 #' ##
 #' # iSEEDESeq2Results ----
 #' ##
-#' 
+#'
 #' # Package the results in a iSEEDESeq2Results object
-#' iseede_table <- iSEEDESeq2Results(res, row.names=rownames(dds))
-#' 
+#' iseede_table <- iSEEDESeq2Results(res, row.names = rownames(dds))
+#'
 #' # Store the iSEEDESeq2Results object in the SummarizedExperiment rowData
-#' rowData(dds)[["iSEEde"]] <- DataFrame(DESeq2=I(iseede_table))
-#' 
+#' rowData(dds)[["iSEEde"]] <- DataFrame(DESeq2 = I(iseede_table))
+#'
 #' dds
-#' 
+#'
 #' ##
 #' # Methods ----
 #' ##
-#' 
+#'
 #' head(pValue(iseede_table))
 #' head(log2FoldChange(iseede_table))
 #' head(averageLog2(iseede_table))
@@ -80,10 +80,10 @@ setClass("iSEEDESeq2Results", contains = "DFrame")
 #' @importFrom methods new is
 #' @importFrom S4Vectors DataFrame
 iSEEDESeq2Results <- function(data, row.names = rownames(data)) {
-  stopifnot(is(data, "DESeqResults"))
-  df <- DataFrame(row.names=row.names)
-  df[rownames(data), colnames(data)] <- data
-  new("iSEEDESeq2Results", df)
+    stopifnot(is(data, "DESeqResults"))
+    df <- DataFrame(row.names = row.names)
+    df[rownames(data), colnames(data)] <- data
+    new("iSEEDESeq2Results", df)
 }
 
 #' @importFrom S4Vectors setValidity2
@@ -92,12 +92,12 @@ setValidity2("iSEEDESeq2Results", function(.Object) {
 
     column_names <- c("baseMean", "log2FoldChange", "pvalue")
     for (name in column_names) {
-      if (!name %in% colnames(.Object)) {
-        msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
-      }
+        if (!name %in% colnames(.Object)) {
+            msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
+        }
     }
 
-    if (length(msg)>0) {
+    if (length(msg) > 0) {
         return(msg)
     }
     TRUE
@@ -105,27 +105,27 @@ setValidity2("iSEEDESeq2Results", function(.Object) {
 
 #' @importMethodsFrom S4Vectors showAsCell
 setMethod("showAsCell", "iSEEDESeq2Results", function(object) {
-  ans <- rep.int("<iSEEDESeq2Results>", nrow(object))
-  ans
+    ans <- rep.int("<iSEEDESeq2Results>", nrow(object))
+    ans
 })
 
 #' @export
 setMethod("pValue", "iSEEDESeq2Results", function(x) {
-  out <- x[["pvalue"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["pvalue"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("log2FoldChange", "iSEEDESeq2Results", function(x) {
-  out <- x[["log2FoldChange"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["log2FoldChange"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("averageLog2", "iSEEDESeq2Results", function(x) {
-  out <- log2(x[["baseMean"]])
-  names(out) <- rownames(x)
-  out
+    out <- log2(x[["baseMean"]])
+    names(out) <- rownames(x)
+    out
 })

--- a/R/iSEEde-package.R
+++ b/R/iSEEde-package.R
@@ -1,14 +1,14 @@
 #' iSEE extension for panels related to differential expression analysis
-#' 
+#'
 #' `iSEEde` is a package that provides panels for \pkg{iSEE},
 #' facilitating the interactive visualisation of differential expression results.
-#' 
+#'
 #' @author Kevin Rue-Albrecht \email{kevin.rue-albrecht@@imm.ox.ac.uk}
-#' 
+#'
 #' @name iSEEde-pkg
 #' @docType package
 #' @keywords internal
-#' 
-#' @examples 
+#'
+#' @examples
 #' library("iSEEde")
 "_PACKAGE"

--- a/R/iSEEedgeR-class.R
+++ b/R/iSEEedgeR-class.R
@@ -1,18 +1,18 @@
 #' The iSEEedgeRResults class
-#' 
+#'
 #' The `iSEEedgeRResults` class is used to provide an common interface to differential expression results produced by the \pkg{edgeR} package.
 #' It provides methods to access common differential expression statistics (e.g., log fold-change, p-value, log2 average abundance).
-#' 
+#'
 #' This class inherits all its slots directly from its parent class \linkS4class{DataFrame}.
-#' 
+#'
 #' @section Constructor:
 #' \code{iSEEedgeRResults(data, row.names = rownames(data))} creates an instance of a `iSEEedgeRResults` class, with:
-#' 
+#'
 #' \describe{
 #' \item{`data`}{A `data.frame` produced by `edgeR::topTags()`.}
 #' \item{`row.names`}{The character vector of rownames for the \linkS4class{SummarizedExperiment} object in which the object is to be embedded. Must be a superset of `rownames(data)`.}
 #' }
-#' 
+#'
 #' @section Supported methods:
 #' \itemize{
 #' \item `embedResults(x, se, name, ...)` embeds `x` in the column `name` of `rowData(se)[["iSEEde"]]`.
@@ -20,9 +20,9 @@
 #' \item `log2FoldChange(x)` returns the vector of log2-fold-change values.
 #' \item `averageLog2(x)` returns the vector of average log2-expression values.
 #' }
-#' 
+#'
 #' @author Kevin Rue-Albrecht
-#' 
+#'
 #' @docType methods
 #' @name iSEEedgeRResults-class
 #' @aliases
@@ -33,48 +33,48 @@
 #' averageLog2,iSEEedgeRResults-method
 #' embedResults,TopTags-method
 #' embedResults,iSEEedgeRResults-method
-#' 
+#'
 #' @examples
 #' library(edgeR)
 #' library(SummarizedExperiment)
-#' 
+#'
 #' ##
 #' # From edgeR::topTags() ----
 #' ##
-#' 
+#'
 #' # generate raw counts from NB, create list object
-#' y <- matrix(rnbinom(80,size=1,mu=10),nrow=20)
-#' d <- DGEList(counts=y,group=rep(1:2,each=2),lib.size=rep(c(1000:1001),2))
-#' rownames(d$counts) <- paste("gene",1:nrow(d$counts),sep=".")
-#' 
+#' y <- matrix(rnbinom(80, size = 1, mu = 10), nrow = 20)
+#' d <- DGEList(counts = y, group = rep(1:2, each = 2), lib.size = rep(c(1000:1001), 2))
+#' rownames(d$counts) <- paste("gene", 1:nrow(d$counts), sep = ".")
+#'
 #' # estimate common dispersion and find differences in expression
 #' # here we demonstrate the 'exact' methods, but the use of topTags is
 #' # the same for a GLM analysis
 #' d <- estimateCommonDisp(d)
 #' de <- exactTest(d)
-#' 
+#'
 #' # look at top 10
 #' res <- topTags(de)
-#' 
+#'
 #' ##
 #' # iSEEedgeRResults ----
 #' ##
-#' 
+#'
 #' # Simulate the original SummarizedExperiment object
-#' se <- SummarizedExperiment(assays = list(counts=d$counts))
-#' 
+#' se <- SummarizedExperiment(assays = list(counts = d$counts))
+#'
 #' # Package the results in a iSEEedgeRResults object
-#' iseede_table <- iSEEedgeRResults(res, row.names=rownames(se))
-#' 
+#' iseede_table <- iSEEedgeRResults(res, row.names = rownames(se))
+#'
 #' # Store the iSEEedgeRResults object in the SummarizedExperiment rowData
-#' rowData(se)[["iSEEde"]] <- DataFrame(edgeR=I(iseede_table))
-#' 
+#' rowData(se)[["iSEEde"]] <- DataFrame(edgeR = I(iseede_table))
+#'
 #' se
-#' 
+#'
 #' ##
 #' # Methods ----
 #' ##
-#' 
+#'
 #' head(pValue(iseede_table))
 #' head(log2FoldChange(iseede_table))
 #' head(averageLog2(iseede_table))
@@ -86,11 +86,11 @@ setClass("iSEEedgeRResults", contains = "DFrame")
 #' @importFrom methods new is
 #' @importFrom S4Vectors DataFrame
 iSEEedgeRResults <- function(data, row.names = rownames(data)) {
-  stopifnot(is(data, "TopTags"))
-  df <- DataFrame(row.names=row.names)
-  # Direct coercion to DataFrame fails because it picks up other named slots
-  df[rownames(data), colnames(data)] <- as.data.frame(data)
-  new("iSEEedgeRResults", df)
+    stopifnot(is(data, "TopTags"))
+    df <- DataFrame(row.names = row.names)
+    # Direct coercion to DataFrame fails because it picks up other named slots
+    df[rownames(data), colnames(data)] <- as.data.frame(data)
+    new("iSEEedgeRResults", df)
 }
 
 #' @importFrom S4Vectors setValidity2
@@ -99,12 +99,12 @@ setValidity2("iSEEedgeRResults", function(.Object) {
 
     column_names <- c("logFC", "logCPM", "PValue")
     for (name in column_names) {
-      if (!name %in% colnames(.Object)) {
-        msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
-      }
+        if (!name %in% colnames(.Object)) {
+            msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
+        }
     }
 
-    if (length(msg)>0) {
+    if (length(msg) > 0) {
         return(msg)
     }
     TRUE
@@ -112,27 +112,27 @@ setValidity2("iSEEedgeRResults", function(.Object) {
 
 #' @importMethodsFrom S4Vectors showAsCell
 setMethod("showAsCell", "iSEEedgeRResults", function(object) {
-  ans <- rep.int("<iSEEedgeRResults>", nrow(object))
-  ans
+    ans <- rep.int("<iSEEedgeRResults>", nrow(object))
+    ans
 })
 
 #' @export
 setMethod("pValue", "iSEEedgeRResults", function(x) {
-  out <- x[["PValue"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["PValue"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("log2FoldChange", "iSEEedgeRResults", function(x) {
-  out <- x[["logFC"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["logFC"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("averageLog2", "iSEEedgeRResults", function(x) {
-  out <- x[["logCPM"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["logCPM"]]
+    names(out) <- rownames(x)
+    out
 })

--- a/R/iSEElimma-class.R
+++ b/R/iSEElimma-class.R
@@ -1,18 +1,18 @@
 #' The iSEELimmaResults class
-#' 
+#'
 #' The `iSEELimmaResults` class is used to provide an common interface to differential expression results produced by the \pkg{limma} package.
 #' It provides methods to access common differential expression statistics (e.g., log fold-change, p-value, log2 average abundance).
-#' 
+#'
 #' This class inherits all its slots directly from its parent class \linkS4class{DataFrame}.
-#' 
+#'
 #' @section Constructor:
 #' \code{iSEELimmaResults(data, row.names = rownames(data))} creates an instance of a `iSEELimmaResults` class, with:
-#' 
+#'
 #' \describe{
 #' \item{`data`}{A `data.frame` produced by `limma::topTable()`.}
 #' \item{`row.names`}{The character vector of rownames for the \linkS4class{SummarizedExperiment} object in which the object is to be embedded. Must be a superset of `rownames(data)`.}
 #' }
-#' 
+#'
 #' @section Supported methods:
 #' \itemize{
 #' \item `embedResults(x, se, name, ...)` embeds `x` in the column `name` of `rowData(se)[["iSEEde"]]`.
@@ -20,9 +20,9 @@
 #' \item `log2FoldChange(x)` returns the vector of log2-fold-change values.
 #' \item `averageLog2(x)` returns the vector of average log2-expression values.
 #' }
-#' 
+#'
 #' @author Kevin Rue-Albrecht
-#' 
+#'
 #' @docType methods
 #' @name iSEELimmaResults-class
 #' @aliases
@@ -32,46 +32,46 @@
 #' log2FoldChange,iSEELimmaResults-method
 #' averageLog2,iSEELimmaResults-method
 #' embedResults,iSEELimmaResults-method
-#' 
+#'
 #' @examples
 #' library(limma)
 #' library(SummarizedExperiment)
-#' 
+#'
 #' ##
 #' # From limma::lmFit() ----
 #' ##
-#' 
-#' sd <- 0.3*sqrt(4/rchisq(100,df=4))
-#' y <- matrix(rnorm(100*6,sd=sd),100,6)
-#' rownames(y) <- paste("Gene",1:100)
-#' y[1:2,4:6] <- y[1:2,4:6] + 2
-#' design <- cbind(Grp1=1, Grp2vs1=c(0,0,0,1,1,1))
-#' 
+#'
+#' sd <- 0.3 * sqrt(4 / rchisq(100, df = 4))
+#' y <- matrix(rnorm(100 * 6, sd = sd), 100, 6)
+#' rownames(y) <- paste("Gene", 1:100)
+#' y[1:2, 4:6] <- y[1:2, 4:6] + 2
+#' design <- cbind(Grp1 = 1, Grp2vs1 = c(0, 0, 0, 1, 1, 1))
+#'
 # Ordinary fit
-#' fit <- lmFit(y,design)
+#' fit <- lmFit(y, design)
 #' fit <- eBayes(fit)
-#' tt <- topTable(fit, coef=2)
+#' tt <- topTable(fit, coef = 2)
 #' head(tt)
-#' 
+#'
 #' ##
 #' # iSEELimmaResults ----
 #' ##
-#' 
+#'
 #' # Simulate the original SummarizedExperiment object
-#' se <- SummarizedExperiment(assays = list(counts=y))
-#' 
+#' se <- SummarizedExperiment(assays = list(counts = y))
+#'
 #' # Package the results in a iSEELimmaResults object
-#' iseede_table <- iSEELimmaResults(tt, row.names=rownames(y))
-#' 
+#' iseede_table <- iSEELimmaResults(tt, row.names = rownames(y))
+#'
 #' # Store the iSEELimmaResults object in the SummarizedExperiment rowData
-#' rowData(se)[["iSEEde"]] <- DataFrame(limma=I(iseede_table))
-#' 
+#' rowData(se)[["iSEEde"]] <- DataFrame(limma = I(iseede_table))
+#'
 #' se
-#' 
+#'
 #' ##
 #' # Methods ----
 #' ##
-#' 
+#'
 #' head(pValue(iseede_table))
 #' head(log2FoldChange(iseede_table))
 #' head(averageLog2(iseede_table))
@@ -83,9 +83,9 @@ setClass("iSEELimmaResults", contains = "DFrame")
 #' @importFrom methods new
 #' @importFrom S4Vectors DataFrame
 iSEELimmaResults <- function(data, row.names = rownames(data)) {
-  df <- DataFrame(row.names=row.names)
-  df[rownames(data), colnames(data)] <- data
-  new("iSEELimmaResults", df)
+    df <- DataFrame(row.names = row.names)
+    df[rownames(data), colnames(data)] <- data
+    new("iSEELimmaResults", df)
 }
 
 #' @importFrom S4Vectors setValidity2
@@ -94,12 +94,12 @@ setValidity2("iSEELimmaResults", function(.Object) {
 
     column_names <- c("logFC", "AveExpr", "P.Value")
     for (name in column_names) {
-      if (!name %in% colnames(.Object)) {
-        msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
-      }
+        if (!name %in% colnames(.Object)) {
+            msg <- c(msg, sprintf("'%s' must exist in colnames(.Object)", name))
+        }
     }
 
-    if (length(msg)>0) {
+    if (length(msg) > 0) {
         return(msg)
     }
     TRUE
@@ -107,27 +107,27 @@ setValidity2("iSEELimmaResults", function(.Object) {
 
 #' @importMethodsFrom S4Vectors showAsCell
 setMethod("showAsCell", "iSEELimmaResults", function(object) {
-  ans <- rep.int("<iSEELimmaResults>", nrow(object))
-  ans
+    ans <- rep.int("<iSEELimmaResults>", nrow(object))
+    ans
 })
 
 #' @export
 setMethod("pValue", "iSEELimmaResults", function(x) {
-  out <- x[["P.Value"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["P.Value"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("log2FoldChange", "iSEELimmaResults", function(x) {
-  out <- x[["logFC"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["logFC"]]
+    names(out) <- rownames(x)
+    out
 })
 
 #' @export
 setMethod("averageLog2", "iSEELimmaResults", function(x) {
-  out <- x[["AveExpr"]]
-  names(out) <- rownames(x)
-  out
+    out <- x[["AveExpr"]]
+    names(out) <- rownames(x)
+    out
 })

--- a/R/utils-SummarizedExperiment.R
+++ b/R/utils-SummarizedExperiment.R
@@ -1,88 +1,94 @@
 #' @export
-#' 
+#'
 #' @rdname utils-SummarizedExperiment
 embedResultsMethods <- c(
-  "limma" = "iSEELimmaResults"
+    "limma" = "iSEELimmaResults"
 )
 
 #' @export
 setMethod("embedResults", "ANY", function(x, se, name, ...) {
-  msg <- sprintf("no 'embedResults' method defined for object
+    msg <- sprintf(
+        "no 'embedResults' method defined for object
       of class %s, consider defining your own.",
-      sQuote(class(x)))
-  stop(paste(strwrap(msg), collapse="\n"))
+        sQuote(class(x))
+    )
+    stop(paste(strwrap(msg), collapse = "\n"))
 })
 
 #' @importFrom SummarizedExperiment rowData rowData<-
 #' @importFrom S4Vectors DataFrame
 .embed_de_result <- function(x, se, name) {
-  iseede_data <- rowData(se)[["iSEEde"]]
-  if (is.null(iseede_data)) {
-    iseede_data <- DataFrame(row.names = rownames(se))
-  }
-  if (name %in% names(iseede_data)) {
-    msg <- sprintf("Results already exist under name %s.
+    iseede_data <- rowData(se)[["iSEEde"]]
+    if (is.null(iseede_data)) {
+        iseede_data <- DataFrame(row.names = rownames(se))
+    }
+    if (name %in% names(iseede_data)) {
+        msg <- sprintf(
+            "Results already exist under name %s.
         Replacing with new results.\n",
-        sQuote(name))
-    warning(paste(strwrap(msg), collapse="\n"))
-  }
-  iseede_data[[name]] <- x
-  rowData(se)[["iSEEde"]] <- iseede_data
-  se
+            sQuote(name)
+        )
+        warning(paste(strwrap(msg), collapse = "\n"))
+    }
+    iseede_data[[name]] <- x
+    rowData(se)[["iSEEde"]] <- iseede_data
+    se
 }
 
 #' @export
-#' 
+#'
 #' @param x Object to be embedded.
 #' @param se A \linkS4class{SummarizedExperiment} object.
 #' @param name Identifier for the embedded object.
 #' @param class Class to use for embedding `x`. Only used when `class(x)` does
 #' not uniquely identify the package that generated the object.
 #' @param ... Arguments passed to and from other methods.
-#' 
+#'
 #' @return An updated \linkS4class{SummarizedExperiment} object that contains the
 #' embedded object.
-#' 
+#'
 #' @rdname utils-SummarizedExperiment
 #' @aliases embedResults,data.frame-method
 setMethod("embedResults", "data.frame", function(x, se, name, class, ...) {
-  if (!class %in% names(embedResultsMethods)) {
-    msg <- sprintf("argument %s must be a value in %s,
+    if (!class %in% names(embedResultsMethods)) {
+        msg <- sprintf(
+            "argument %s must be a value in %s,
       for signature %s.",
-      sQuote("class"), sQuote("names(embedResultsMethods)"),
-      sQuote("x=data.frame"))
-    stop(paste(strwrap(msg), collapse="\n"))
-  }
-  constructor <- get(embedResultsMethods[class])
-  res <- constructor(x, row.names=rownames(se))
-  embedResults(res, se, name, ...)
+            sQuote("class"), sQuote("names(embedResultsMethods)"),
+            sQuote("x=data.frame")
+        )
+        stop(paste(strwrap(msg), collapse = "\n"))
+    }
+    constructor <- get(embedResultsMethods[class])
+    res <- constructor(x, row.names = rownames(se))
+    embedResults(res, se, name, ...)
 })
 
 #' @export
 setMethod("embedResults", "iSEELimmaResults", function(x, se, name, ...) {
-  .embed_de_result(x, se, name)
+    .embed_de_result(x, se, name)
 })
 
 #' @export
 #' @importClassesFrom DESeq2 DESeqResults
 setMethod("embedResults", "DESeqResults", function(x, se, name, ...) {
-  res <- iSEEDESeq2Results(x, row.names = rownames(se))
-  embedResults(res, se, name)
+    res <- iSEEDESeq2Results(x, row.names = rownames(se))
+    embedResults(res, se, name)
 })
 
 #' @export
 setMethod("embedResults", "iSEEDESeq2Results", function(x, se, name, ...) {
-  .embed_de_result(x, se, name)
+    .embed_de_result(x, se, name)
 })
 
 #' @export
 #' @importClassesFrom edgeR TopTags
 setMethod("embedResults", "TopTags", function(x, se, name, ...) {
-  res <- iSEEedgeRResults(x, row.names = rownames(se))
-  embedResults(res, se, name)
+    res <- iSEEedgeRResults(x, row.names = rownames(se))
+    embedResults(res, se, name)
 })
 
 #' @export
 setMethod("embedResults", "iSEEedgeRResults", function(x, se, name, ...) {
-  .embed_de_result(x, se, name)
+    .embed_de_result(x, se, name)
 })

--- a/README.Rmd
+++ b/README.Rmd
@@ -68,12 +68,12 @@ res_deseq2 <- results(dds, contrast = list("dextrt", "dexuntrt"))
 airway <- embedResults(res_deseq2, airway, name = "DESeq2")
 
 app <- iSEE(airway, initial = list(
-  VolcanoPlot(ContrastName="dextrt vs dexuntrt", PanelWidth = 6L),
-  MAPlot(ContrastName="dextrt vs dexuntrt", PanelWidth = 6L)
+    VolcanoPlot(ContrastName = "dextrt vs dexuntrt", PanelWidth = 6L),
+    MAPlot(ContrastName = "dextrt vs dexuntrt", PanelWidth = 6L)
 ))
 
 if (interactive()) {
-  shiny::runApp(app)
+    shiny::runApp(app)
 }
 ```
 
@@ -83,7 +83,7 @@ Below is the citation output from using `citation('iSEEde')` in R. Please
 run this yourself to check for any updates on how to cite __iSEEde__.
 
 ```{r 'citation', eval = requireNamespace('iSEEde')}
-print(citation('iSEEde'), bibtex = TRUE)
+print(citation("iSEEde"), bibtex = TRUE)
 ```
 
 Please note that the `iSEEde` was only made possible thanks to many other R and bioinformatics software authors, which are cited either in the vignettes and/or the paper(s) describing this package.

--- a/tests/testthat/setup-de.R
+++ b/tests/testthat/setup-de.R
@@ -5,21 +5,23 @@ library(SummarizedExperiment)
 # see vignette for suggestions on generating
 # count tables from RNA-Seq data
 set.seed(1)
-cnts <- matrix(rnbinom(n=1000, mu=100, size=1/0.5), ncol=10)
+cnts <- matrix(rnbinom(n = 1000, mu = 100, size = 1 / 0.5), ncol = 10)
 storage.mode(cnts) <- "integer"
 rownames(cnts) <- paste0("gene", seq_len(nrow(cnts)))
-cond <- factor(rep(1:2, each=5))
+cond <- factor(rep(1:2, each = 5))
 
-se <- SummarizedExperiment(assays = list(counts = cnts), 
-                           colData = DataFrame(cond))
+se <- SummarizedExperiment(
+    assays = list(counts = cnts),
+    colData = DataFrame(cond)
+)
 rm(cnts, cond)
 
 # DESeq2 ---
 
 library(DESeq2)
 
-dds <- DESeqDataSet(se, ~ cond)
-dds <- DESeq(dds, fitType='local')
+dds <- DESeqDataSet(se, ~cond)
+dds <- DESeq(dds, fitType = "local")
 res_deseq2 <- results(dds)
 
 rm(dds)
@@ -30,7 +32,7 @@ library(edgeR)
 
 design <- model.matrix(~ 0 + cond, data = colData(se))
 
-fit <- glmFit(se, design, dispersion=0.1)
+fit <- glmFit(se, design, dispersion = 0.1)
 lrt <- glmLRT(fit, contrast = c(-1, 1))
 res_edger <- topTags(lrt, n = Inf)
 
@@ -41,7 +43,7 @@ rm(design, fit, lrt)
 design <- model.matrix(~ 0 + cond, data = colData(se))
 
 keep <- filterByExpr(se, design)
-fit <- voomLmFit(se[keep,], design, plot = FALSE)
+fit <- voomLmFit(se[keep, ], design, plot = FALSE)
 contr <- makeContrasts("cond2 - cond1", levels = design)
 fit <- contrasts.fit(fit, contr)
 fit <- eBayes(fit)

--- a/tests/testthat/setup-de.R
+++ b/tests/testthat/setup-de.R
@@ -10,7 +10,8 @@ storage.mode(cnts) <- "integer"
 rownames(cnts) <- paste0("gene", seq_len(nrow(cnts)))
 cond <- factor(rep(1:2, each=5))
 
-se <- SummarizedExperiment(assays = list(counts = cnts), colData = DataFrame(cond))
+se <- SummarizedExperiment(assays = list(counts = cnts), 
+                           colData = DataFrame(cond))
 rm(cnts, cond)
 
 # DESeq2 ---
@@ -18,7 +19,7 @@ rm(cnts, cond)
 library(DESeq2)
 
 dds <- DESeqDataSet(se, ~ cond)
-dds <- DESeq(dds)
+dds <- DESeq(dds, fitType='local')
 res_deseq2 <- results(dds)
 
 rm(dds)
@@ -27,26 +28,23 @@ rm(dds)
 
 library(edgeR)
 
-counts <- assay(se, "counts")
 design <- model.matrix(~ 0 + cond, data = colData(se))
 
-fit <- glmFit(counts, design, dispersion=0.1)
+fit <- glmFit(se, design, dispersion=0.1)
 lrt <- glmLRT(fit, contrast = c(-1, 1))
 res_edger <- topTags(lrt, n = Inf)
 
-rm(counts, design, fit, lrt)
+rm(design, fit, lrt)
 
 # limma ----
 
-counts <- assay(se, "counts")
 design <- model.matrix(~ 0 + cond, data = colData(se))
 
-keep <- filterByExpr(counts, design)
-v <- voom(counts[keep,], design, plot=FALSE)
-fit <- lmFit(v, design)
-contr <- makeContrasts("cond2 - cond1", levels = colnames(coef(fit)))
-tmp <- contrasts.fit(fit, contr)
-tmp <- eBayes(tmp)
-res_limma <- topTable(tmp, sort.by = "P", n = Inf)
+keep <- filterByExpr(se, design)
+fit <- voomLmFit(se[keep,], design, plot = FALSE)
+contr <- makeContrasts("cond2 - cond1", levels = design)
+fit <- contrasts.fit(fit, contr)
+fit <- eBayes(fit)
+res_limma <- topTable(fit, sort.by = "P", n = Inf)
 
-rm(counts, design, keep, v, fit, contr, tmp)
+rm(design, keep, fit, contr)

--- a/tests/testthat/test-deseq2.R
+++ b/tests/testthat/test-deseq2.R
@@ -1,51 +1,41 @@
 test_that("iSEEDESeq2Results() constructor works", {
-  
-  out <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
-  
-  expect_s4_class(out, "iSEEDESeq2Results")
-  
+    out <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
+
+    expect_s4_class(out, "iSEEDESeq2Results")
 })
 
 test_that("show(iSEEDESeq2Results) works", {
-  
-  x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
-  out <- DataFrame(row.names = rownames(se))
-  out[["DESeq2"]] <- x
-  
-  expect_output(show(out), "DataFrame with 100 rows and 1 column")
-  expect_output(show(out), "<iSEEDESeq2Results>")
-  
+    x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
+    out <- DataFrame(row.names = rownames(se))
+    out[["DESeq2"]] <- x
+
+    expect_output(show(out), "DataFrame with 100 rows and 1 column")
+    expect_output(show(out), "<iSEEDESeq2Results>")
 })
 
 test_that("pValue(iSEEDESeq2Results) works", {
-  
-  x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
-  out <- pValue(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
+    out <- pValue(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("log2FoldChange(iSEEDESeq2Results) works", {
-  
-  x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
-  out <- log2FoldChange(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
+    out <- log2FoldChange(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("averageLog2(iSEEDESeq2Results) works", {
-  
-  x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
-  out <- averageLog2(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEDESeq2Results(res_deseq2, row.names = rownames(se))
+    out <- averageLog2(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })

--- a/tests/testthat/test-edgeR.R
+++ b/tests/testthat/test-edgeR.R
@@ -1,51 +1,41 @@
 test_that("iSEEedgeRResults() constructor works", {
-  
-  out <- iSEEedgeRResults(res_edger, row.names = rownames(se))
-  
-  expect_s4_class(out, "iSEEedgeRResults")
-  
+    out <- iSEEedgeRResults(res_edger, row.names = rownames(se))
+
+    expect_s4_class(out, "iSEEedgeRResults")
 })
 
 test_that("show(iSEEedgeRResults) works", {
-  
-  x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
-  out <- DataFrame(row.names = rownames(se))
-  out[["edgeR"]] <- x
-  
-  expect_output(show(out), "DataFrame with 100 rows and 1 column")
-  expect_output(show(out), "<iSEEedgeRResults>")
-  
+    x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
+    out <- DataFrame(row.names = rownames(se))
+    out[["edgeR"]] <- x
+
+    expect_output(show(out), "DataFrame with 100 rows and 1 column")
+    expect_output(show(out), "<iSEEedgeRResults>")
 })
 
 test_that("pValue(iSEEedgeRResults) works", {
-  
-  x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
-  out <- pValue(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
+    out <- pValue(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("log2FoldChange(iSEEedgeRResults) works", {
-  
-  x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
-  out <- log2FoldChange(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
+    out <- log2FoldChange(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("averageLog2(iSEEedgeRResults) works", {
-  
-  x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
-  out <- averageLog2(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEEedgeRResults(res_edger, row.names = rownames(se))
+    out <- averageLog2(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })

--- a/tests/testthat/test-embed.R
+++ b/tests/testthat/test-embed.R
@@ -1,57 +1,49 @@
 test_that("embedResults(ANY) works", {
-  
-  x <- character()
-  
-  expect_error(
-    embedResults(x, se, name = "ERROR"),
-    "no 'embedResults' method defined for object of class"
-  )
-  
+    x <- character()
+
+    expect_error(
+        embedResults(x, se, name = "ERROR"),
+        "no 'embedResults' method defined for object of class"
+    )
 })
 
 test_that("embedResults(data.frame) works", {
-  
-  expect_error(
-    embedResults(res_limma, se, name = "limma"),
-    'argument "class" is missing, with no default'
-  )
-  
-  expect_error(
-    embedResults(res_limma, se, name = "limma", class = "ERROR"),
-    "must be a value in"
-  )
-  
-  out <- embedResults(res_limma, se, name = "limma", class = "limma")
-  
-  expect_s4_class(out, "SummarizedExperiment")
-  expect_named(rowData(out), "iSEEde")
-  expect_named(rowData(out)[["iSEEde"]], "limma")
-  
-  expect_warning(
-    embedResults(res_limma, out, name = "limma", class = "limma"),
-    "Results already exist under name"
-  )
-  
+    expect_error(
+        embedResults(res_limma, se, name = "limma"),
+        'argument "class" is missing, with no default'
+    )
+
+    expect_error(
+        embedResults(res_limma, se, name = "limma", class = "ERROR"),
+        "must be a value in"
+    )
+
+    out <- embedResults(res_limma, se, name = "limma", class = "limma")
+
+    expect_s4_class(out, "SummarizedExperiment")
+    expect_named(rowData(out), "iSEEde")
+    expect_named(rowData(out)[["iSEEde"]], "limma")
+
+    expect_warning(
+        embedResults(res_limma, out, name = "limma", class = "limma"),
+        "Results already exist under name"
+    )
 })
 
 
 test_that("embedResults(DESeqResults) works", {
-  
-  out <- embedResults(res_deseq2, se, name = "DESeq2")
-  
-  expect_s4_class(out, "SummarizedExperiment")
-  expect_named(rowData(out), "iSEEde")
-  expect_named(rowData(out)[["iSEEde"]], "DESeq2")
-  
+    out <- embedResults(res_deseq2, se, name = "DESeq2")
+
+    expect_s4_class(out, "SummarizedExperiment")
+    expect_named(rowData(out), "iSEEde")
+    expect_named(rowData(out)[["iSEEde"]], "DESeq2")
 })
 
 
 test_that("embedResults(TopTags) works", {
-  
-  out <- embedResults(res_deseq2, se, name = "edgeR")
-  
-  expect_s4_class(out, "SummarizedExperiment")
-  expect_named(rowData(out), "iSEEde")
-  expect_named(rowData(out)[["iSEEde"]], "edgeR")
-  
+    out <- embedResults(res_deseq2, se, name = "edgeR")
+
+    expect_s4_class(out, "SummarizedExperiment")
+    expect_named(rowData(out), "iSEEde")
+    expect_named(rowData(out)[["iSEEde"]], "edgeR")
 })

--- a/tests/testthat/test-limma.R
+++ b/tests/testthat/test-limma.R
@@ -1,51 +1,41 @@
 test_that("iSEELimmaResults() constructor works", {
-  
-  out <- iSEELimmaResults(res_limma, row.names = rownames(se))
-  
-  expect_s4_class(out, "iSEELimmaResults")
-  
+    out <- iSEELimmaResults(res_limma, row.names = rownames(se))
+
+    expect_s4_class(out, "iSEELimmaResults")
 })
 
 test_that("showAsCell(iSEELimmaResults) works", {
-  
-  x <- iSEELimmaResults(res_limma, row.names = rownames(se))
-  out <- DataFrame(row.names = rownames(se))
-  out[["limma"]] <- x
-  
-  expect_output(show(out), "DataFrame with 100 rows and 1 column")
-  expect_output(show(out), "<iSEELimmaResults>")
-  
+    x <- iSEELimmaResults(res_limma, row.names = rownames(se))
+    out <- DataFrame(row.names = rownames(se))
+    out[["limma"]] <- x
+
+    expect_output(show(out), "DataFrame with 100 rows and 1 column")
+    expect_output(show(out), "<iSEELimmaResults>")
 })
 
 test_that("pValue(iSEELimmaResults) works", {
-  
-  x <- iSEELimmaResults(res_limma, row.names = rownames(se))
-  out <- pValue(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEELimmaResults(res_limma, row.names = rownames(se))
+    out <- pValue(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("log2FoldChange(iSEELimmaResults) works", {
-  
-  x <- iSEELimmaResults(res_limma, row.names = rownames(se))
-  out <- log2FoldChange(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEELimmaResults(res_limma, row.names = rownames(se))
+    out <- log2FoldChange(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })
 
 test_that("averageLog2(iSEELimmaResults) works", {
-  
-  x <- iSEELimmaResults(res_limma, row.names = rownames(se))
-  out <- averageLog2(x)
-  
-  expect_type(out, "double")
-  expect_length(out, nrow(x))
-  expect_named(out, rownames(x))
-  
+    x <- iSEELimmaResults(res_limma, row.names = rownames(se))
+    out <- averageLog2(x)
+
+    expect_type(out, "double")
+    expect_length(out, nrow(x))
+    expect_named(out, rownames(x))
 })

--- a/tests/testthat/test-ma-plot.R
+++ b/tests/testthat/test-ma-plot.R
@@ -1,96 +1,78 @@
 test_that("MAPlot() constructor works", {
-  
-  out <- MAPlot()
-  
-  expect_s4_class(out, "MAPlot")
-  
+    out <- MAPlot()
+
+    expect_s4_class(out, "MAPlot")
 })
 
 test_that(".fullName(MAPlot) works", {
-  
-  x <- MAPlot()
-  out <- .fullName(x)
-  
-  expect_identical(out, "MA plot")
-  
+    x <- MAPlot()
+    out <- .fullName(x)
+
+    expect_identical(out, "MA plot")
 })
 
 test_that(".panelColor(MAPlot) works", {
-  
-  x <- MAPlot()
-  out <- .panelColor(x)
-  
-  expect_identical(out, "#DEAE10")
-  
+    x <- MAPlot()
+    out <- .panelColor(x)
+
+    expect_identical(out, "#DEAE10")
 })
 
 test_that("cacheCommonInfo(MAPlot) works", {
-  
-  x <- MAPlot()
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  out <- .cacheCommonInfo(x, se0)
-  
-  expect_s4_class(out, "SummarizedExperiment")
-  expect_identical(metadata(out)$iSEE$cached$MAPlot$valid.contrast.names, "edgeR")
-  
-  # Run one more time on the output object for complete coverage
-  .cacheCommonInfo(x, out)
-  
+    x <- MAPlot()
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    out <- .cacheCommonInfo(x, se0)
+
+    expect_s4_class(out, "SummarizedExperiment")
+    expect_identical(metadata(out)$iSEE$cached$MAPlot$valid.contrast.names, "edgeR")
+
+    # Run one more time on the output object for complete coverage
+    .cacheCommonInfo(x, out)
 })
 
 test_that(".refineParameters(MAPlot) works", {
-  
-  x <- MAPlot()
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  se0 <- .cacheCommonInfo(x, se0)
-  out <- .refineParameters(x, se0)
-  
-  expect_s4_class(out, "MAPlot")
-  expect_identical(out[["ContrastName"]], "edgeR")
-  
+    x <- MAPlot()
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    se0 <- .cacheCommonInfo(x, se0)
+    out <- .refineParameters(x, se0)
+
+    expect_s4_class(out, "MAPlot")
+    expect_identical(out[["ContrastName"]], "edgeR")
 })
 
 test_that(".refineParameters(MAPlot) works on NULL object", {
-  
-  FUN <- getMethod(".refineParameters", "MAPlot")
-  expect_null(FUN(NULL, se))
-  
+    FUN <- getMethod(".refineParameters", "MAPlot")
+    expect_null(FUN(NULL, se))
 })
 
 
 test_that(".createObservers(MAPlot) works", {
-  
-  x <- MAPlot()
-  out <- .createObservers(x, se, NULL, NULL, NULL, NULL)
-  
-  expect_null(out)
-  
+    x <- MAPlot()
+    out <- .createObservers(x, se, NULL, NULL, NULL, NULL)
+
+    expect_null(out)
 })
 
 test_that(".defineDataInterface(MAplot) works", {
-  
-  x <- MAPlot(PanelId=1L)
-  out <- .defineDataInterface(x, se)
-  
-  expect_true(any(grepl("MAPlot1_ContrastName", unlist(out))))
-  
+    x <- MAPlot(PanelId = 1L)
+    out <- .defineDataInterface(x, se)
+
+    expect_true(any(grepl("MAPlot1_ContrastName", unlist(out))))
 })
 
 test_that(".generateDotPlotData(MAplot) works", {
-  
-  x <- MAPlot()
-  x[["ContrastName"]] <- "edgeR"
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  se0 <- .cacheCommonInfo(x, se0)
-  x <- .refineParameters(x, se0)
-  env <- new.env()
-  env$se <- se0
-  out <- .generateDotPlotData(x, env)
-  
-  expect_match(out$commands["x"], "iSEEde::averageLog2")
-  expect_true(any(grepl("iSEEde::log2FoldChange", unlist(out$commands))))
-  
+    x <- MAPlot()
+    x[["ContrastName"]] <- "edgeR"
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    se0 <- .cacheCommonInfo(x, se0)
+    x <- .refineParameters(x, se0)
+    env <- new.env()
+    env$se <- se0
+    out <- .generateDotPlotData(x, env)
+
+    expect_match(out$commands["x"], "iSEEde::averageLog2")
+    expect_true(any(grepl("iSEEde::log2FoldChange", unlist(out$commands))))
 })

--- a/tests/testthat/test-volcano-plot.R
+++ b/tests/testthat/test-volcano-plot.R
@@ -1,95 +1,77 @@
 test_that("VolcanoPlot() constructor works", {
-  
-  out <- VolcanoPlot()
-  
-  expect_s4_class(out, "VolcanoPlot")
-  
+    out <- VolcanoPlot()
+
+    expect_s4_class(out, "VolcanoPlot")
 })
 
 test_that(".fullName(VolcanoPlot) works", {
-  
-  x <- VolcanoPlot()
-  out <- .fullName(x)
-  
-  expect_identical(out, "Volcano plot")
-  
+    x <- VolcanoPlot()
+    out <- .fullName(x)
+
+    expect_identical(out, "Volcano plot")
 })
 
 test_that(".panelColor(VolcanoPlot) works", {
-  
-  x <- VolcanoPlot()
-  out <- .panelColor(x)
-  
-  expect_identical(out, "#DEAE10")
-  
+    x <- VolcanoPlot()
+    out <- .panelColor(x)
+
+    expect_identical(out, "#DEAE10")
 })
 
 test_that("cacheCommonInfo(VolcanoPlot) works", {
-  
-  x <- VolcanoPlot()
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  out <- .cacheCommonInfo(x, se0)
-  
-  expect_s4_class(out, "SummarizedExperiment")
-  expect_identical(metadata(out)$iSEE$cached$VolcanoPlot$valid.contrast.names, "edgeR")
-  
-  # Run one more time on the output object for complete coverage
-  .cacheCommonInfo(x, out)
-  
+    x <- VolcanoPlot()
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    out <- .cacheCommonInfo(x, se0)
+
+    expect_s4_class(out, "SummarizedExperiment")
+    expect_identical(metadata(out)$iSEE$cached$VolcanoPlot$valid.contrast.names, "edgeR")
+
+    # Run one more time on the output object for complete coverage
+    .cacheCommonInfo(x, out)
 })
 
 test_that(".refineParameters(VolcanoPlot) works", {
-  
-  x <- VolcanoPlot()
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  se0 <- .cacheCommonInfo(x, se0)
-  out <- .refineParameters(x, se0)
-  
-  expect_s4_class(out, "VolcanoPlot")
-  expect_identical(out[["ContrastName"]], "edgeR")
-  
+    x <- VolcanoPlot()
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    se0 <- .cacheCommonInfo(x, se0)
+    out <- .refineParameters(x, se0)
+
+    expect_s4_class(out, "VolcanoPlot")
+    expect_identical(out[["ContrastName"]], "edgeR")
 })
 
 test_that(".refineParameters(VolcanoPlot) works on NULL object", {
-  
-  FUN <- getMethod(".refineParameters", "VolcanoPlot")
-  expect_null(FUN(NULL, se))
-  
+    FUN <- getMethod(".refineParameters", "VolcanoPlot")
+    expect_null(FUN(NULL, se))
 })
 
 test_that(".createObservers(VolcanoPlot) works", {
-  
-  x <- VolcanoPlot()
-  out <- .createObservers(x, se, NULL, NULL, NULL, NULL)
-  
-  expect_null(out)
-  
+    x <- VolcanoPlot()
+    out <- .createObservers(x, se, NULL, NULL, NULL, NULL)
+
+    expect_null(out)
 })
 
 test_that(".defineDataInterface(MAplot) works", {
-  
-  x <- VolcanoPlot(PanelId=1L)
-  out <- .defineDataInterface(x, se)
-  
-  expect_true(any(grepl("VolcanoPlot1_ContrastName", unlist(out))))
-  
+    x <- VolcanoPlot(PanelId = 1L)
+    out <- .defineDataInterface(x, se)
+
+    expect_true(any(grepl("VolcanoPlot1_ContrastName", unlist(out))))
 })
 
 test_that(".generateDotPlotData(MAplot) works", {
-  
-  x <- VolcanoPlot()
-  x[["ContrastName"]] <- "edgeR"
-  se0 <- se
-  se0 <- embedResults(res_edger, se0, name = "edgeR")
-  se0 <- .cacheCommonInfo(x, se0)
-  x <- .refineParameters(x, se0)
-  env <- new.env()
-  env$se <- se0
-  out <- .generateDotPlotData(x, env)
-  
-  expect_match(out$commands["x"], "iSEEde::log2FoldChange")
-  expect_true(any(grepl("iSEEde::pValue", unlist(out$commands))))
-  
+    x <- VolcanoPlot()
+    x[["ContrastName"]] <- "edgeR"
+    se0 <- se
+    se0 <- embedResults(res_edger, se0, name = "edgeR")
+    se0 <- .cacheCommonInfo(x, se0)
+    x <- .refineParameters(x, se0)
+    env <- new.env()
+    env$se <- se0
+    out <- .generateDotPlotData(x, env)
+
+    expect_match(out$commands["x"], "iSEEde::log2FoldChange")
+    expect_true(any(grepl("iSEEde::pValue", unlist(out$commands))))
 })

--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -82,8 +82,10 @@ additional column of the `rowData()` component.
 
 ```{r, message=FALSE, warning=FALSE}
 library("org.Hs.eg.db")
-rowData(airway)[["SYMBOL"]] <- mapIds(org.Hs.eg.db, rownames(airway),
-                                      "SYMBOL", "ENSEMBL")
+rowData(airway)[["SYMBOL"]] <- mapIds(
+    org.Hs.eg.db, rownames(airway),
+    "SYMBOL", "ENSEMBL"
+)
 ```
 
 Next, we use the `uniquifyFeatureNames()` function of the 
@@ -98,8 +100,8 @@ unique identifier that is generated as follows:
 ```{r, message=FALSE, warning=FALSE}
 library("scuttle")
 rownames(airway) <- uniquifyFeatureNames(
-  ID = rowData(airway)[["ENSEMBL"]],
-  names = rowData(airway)[["SYMBOL"]]
+    ID = rowData(airway)[["ENSEMBL"]],
+    names = rowData(airway)[["SYMBOL"]]
 )
 airway
 ```
@@ -125,7 +127,7 @@ library("edgeR")
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
 keep <- filterByExpr(airway, design)
-fit <- voomLmFit(airway[keep,], design, plot=FALSE)
+fit <- voomLmFit(airway[keep, ], design, plot = FALSE)
 contr <- makeContrasts("dextrt - dexuntrt", levels = design)
 fit <- contrasts.fit(fit, contr)
 fit <- eBayes(fit)
@@ -137,8 +139,10 @@ Then, we embed this set of differential expression results in the `airway` objec
 
 ```{r}
 library(iSEEde)
-airway <- embedResults(res_limma, airway, name = "dextrt - dexuntrt", 
-                       class = "limma")
+airway <- embedResults(res_limma, airway,
+    name = "dextrt - dexuntrt",
+    class = "limma"
+)
 rowData(airway)
 ```
 
@@ -160,17 +164,17 @@ panelDefaults(
 )
 
 app <- iSEE(airway, initial = list(
-  VolcanoPlot(ContrastName="dextrt - dexuntrt", PanelWidth = 6L),
-  MAPlot(ContrastName="dextrt - dexuntrt", PanelWidth = 6L)
+    VolcanoPlot(ContrastName = "dextrt - dexuntrt", PanelWidth = 6L),
+    MAPlot(ContrastName = "dextrt - dexuntrt", PanelWidth = 6L)
 ))
 
 if (interactive()) {
-  shiny::runApp(app)
+    shiny::runApp(app)
 }
 ```
 
 ```{r, echo=FALSE, out.width="100%"}
-SCREENSHOT("screenshots/using_annotations.png", delay=20)
+SCREENSHOT("screenshots/using_annotations.png", delay = 20)
 ```
 
 # Reproducibility

--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -55,43 +55,48 @@ bib <- c(
 
 # Example data
 
-We use the `?airway` data set.
-
-We briefly adjust the reference level of the treatment factor to the untreated condition.
+We use the `?airway` data set. 
 
 ```{r, message=FALSE, warning=FALSE}
 library("airway")
 data("airway")
-airway$dex <- relevel(airway$dex, "untrt")
 ```
 
 # Annotating data
 
-This section demonstrates one of many possible workflows for adding annotations to the data set.
-Those annotations are meant to make 
+This section demonstrates one of many possible workflows for adding annotations
+to the data set. Those annotations are meant to make it easier for users to
+identify genes of interest, e.g. by displaying both gene symbols and ENSEMBL 
+gene identifiers as tooltips in the interactive browser.
 
-First, we make a copy of the Ensembl identifiers -- currently stored in the `rownames()` -- to a column in the `rowData()` component.
+First, we make a copy of the Ensembl identifiers -- currently stored in the 
+`rownames()` -- to a column in the `rowData()` component.
 
 ```{r}
 rowData(airway)[["ENSEMBL"]] <- rownames(airway)
 ```
 
-Then, we use the `r BiocStyle::Biocpkg("org.Hs.eg.db")` package to map the Ensembl identifiers to gene symbols.
-We store those gene symbols as an additional column of the `rowData()` component.
+Then, we use the `r BiocStyle::Biocpkg("org.Hs.eg.db")` package to map the 
+Ensembl identifiers to gene symbols. We store those gene symbols as an
+additional column of the `rowData()` component.
 
 ```{r, message=FALSE, warning=FALSE}
 library("org.Hs.eg.db")
-rowData(airway)[["SYMBOL"]] <- mapIds(org.Hs.eg.db, rownames(airway), "SYMBOL", "ENSEMBL")
+rowData(airway)[["SYMBOL"]] <- mapIds(org.Hs.eg.db, rownames(airway),
+                                      "SYMBOL", "ENSEMBL")
 ```
 
-Next, we use the `uniquifyFeatureNames()` function of the `r BiocStyle::Biocpkg("scater")` package to replace the `rownames()` by a unique identifier that is generated as follows:
+Next, we use the `uniquifyFeatureNames()` function of the 
+`r BiocStyle::Biocpkg("scuttle")` package to replace the `rownames()` by a
+unique identifier that is generated as follows:
 
 - The gene symbol if it is unique.
-- A concatenate of the gene symbol and Ensembl gene identifier if the gene symbol is not unique.
+- A concatenate of the gene symbol and Ensembl gene identifier if the gene
+  symbol is not unique.
 - The Ensembl identifier if the gene symbol is not available.
 
 ```{r, message=FALSE, warning=FALSE}
-library("scater")
+library("scuttle")
 rownames(airway) <- uniquifyFeatureNames(
   ID = rowData(airway)[["ENSEMBL"]],
   names = rowData(airway)[["SYMBOL"]]
@@ -101,25 +106,30 @@ airway
 
 # Differential expression
 
-For this example, we run a standard Limma-Voom analysis using `limma::voom()`, `limma::lmFit()`, `limma::makeContrasts()`, and `limma::eBayes()`.
+We first use `edgeR::filterByExpr()` to remove genes whose counts are too low to
+support a rigorous differential expression analysis. Then we run a standard 
+Limma-Voom analysis using `edgeR::voomLmFit()`, `limma::makeContrasts()`, and
+`limma::eBayes()`.  (Alternatively, we could have used `limma::treat()` instead
+of `limma::eBayes()`.)
 
-Before that though, we use `edgeR::filterByExpr()` to filter genes by expression level.
+The linear model includes the `dex` and `cell` covariates, indicating the
+treatment conditions and cell types, respectively. Here, we are interested in 
+differences between treatments, adjusted by cell type, and define this
+comparison as the `dextrt - dexuntrt` contrast.
 
-The differential expression results are fetched using `limma::topTable()`.
+The final differential expression results are fetched using `limma::topTable()`.
 
 ```{r, message=FALSE, warning=FALSE}
 library("edgeR")
 
-counts <- assay(airway, "counts")
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
-keep <- filterByExpr(counts, design)
-v <- voom(counts[keep,], design, plot=FALSE)
-fit <- lmFit(v, design)
-contr <- makeContrasts("dextrt - dexuntrt", levels = colnames(coef(fit)))
-tmp <- contrasts.fit(fit, contr)
-tmp <- eBayes(tmp)
-res_limma <- topTable(tmp, sort.by = "P", n = Inf)
+keep <- filterByExpr(airway, design)
+fit <- voomLmFit(airway[keep,], design, plot=FALSE)
+contr <- makeContrasts("dextrt - dexuntrt", levels = design)
+fit <- contrasts.fit(fit, contr)
+fit <- eBayes(fit)
+res_limma <- topTable(fit, sort.by = "P", n = Inf)
 head(res_limma)
 ```
 
@@ -127,15 +137,18 @@ Then, we embed this set of differential expression results in the `airway` objec
 
 ```{r}
 library(iSEEde)
-airway <- embedResults(res_limma, airway, name = "dextrt - dexuntrt", class = "limma")
+airway <- embedResults(res_limma, airway, name = "dextrt - dexuntrt", 
+                       class = "limma")
 rowData(airway)
 ```
 
 # Live app
 
-In this example, we use `iSEE::panelDefaults()` to specify `rowData()` fields to show in the tooltip that is displayed when hovering a data point.
+In this example, we use `iSEE::panelDefaults()` to specify `rowData()` fields to
+show in the tooltip that is displayed when hovering a data point.
 
-The application is then configured to display the volcano plot and MA plot for the same contrast.
+The application is then configured to display the volcano plot and MA plot for
+the same contrast.
 
 Finally, the configured app is launched.
 
@@ -162,7 +175,8 @@ SCREENSHOT("screenshots/using_annotations.png", delay=20)
 
 # Reproducibility
 
-The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible thanks to:
+The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible
+thanks to:
 
 * R `r Citep(bib[["R"]])`
 * `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
@@ -215,8 +229,10 @@ session_info()
 
 # Bibliography
 
-This vignette was generated using `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
-with `r CRANpkg("knitr")` `r Citep(bib[["knitr"]])` and `r CRANpkg("rmarkdown")` `r Citep(bib[["rmarkdown"]])` running behind the scenes.
+This vignette was generated using `r Biocpkg("BiocStyle")` 
+`r Citep(bib[["BiocStyle"]])` with `r CRANpkg("knitr")` 
+`r Citep(bib[["knitr"]])` and `r CRANpkg("rmarkdown")` 
+`r Citep(bib[["rmarkdown"]])` running behind the scenes.
 
 Citations made with `r CRANpkg("RefManageR")` `r Citep(bib[["RefManageR"]])`.
 

--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -111,8 +111,8 @@ airway
 We first use `edgeR::filterByExpr()` to remove genes whose counts are too low to
 support a rigorous differential expression analysis. Then we run a standard 
 Limma-Voom analysis using `edgeR::voomLmFit()`, `limma::makeContrasts()`, and
-`limma::eBayes()`.  (Alternatively, we could have used `limma::treat()` instead
-of `limma::eBayes()`.)
+`limma::eBayes()` (alternatively, we could have used `limma::treat()` instead
+of `limma::eBayes()`).
 
 The linear model includes the `dex` and `cell` covariates, indicating the
 treatment conditions and cell types, respectively. Here, we are interested in 
@@ -135,7 +135,8 @@ res_limma <- topTable(fit, sort.by = "P", n = Inf)
 head(res_limma)
 ```
 
-Then, we embed this set of differential expression results in the `airway` object using the `embedResults()` method.
+Then, we embed this set of differential expression results in the `airway`
+object using the `embedResults()` method.
 
 ```{r}
 library(iSEEde)
@@ -156,7 +157,7 @@ the same contrast.
 
 Finally, the configured app is launched.
 
-```{r}
+```{r, message=FALSE, warning=FALSE}
 library(iSEE)
 
 panelDefaults(
@@ -198,11 +199,11 @@ Code for creating the vignette
 ```{r createVignette, eval=FALSE}
 ## Create the vignette
 library("rmarkdown")
-system.time(render("methods.Rmd", "BiocStyle::html_document"))
+system.time(render("annotations.Rmd", "BiocStyle::html_document"))
 
 ## Extract the R code
 library("knitr")
-knit("methods.Rmd", tangle = TRUE)
+knit("annotations.Rmd", tangle = TRUE)
 ```
 
 Date the vignette was generated.

--- a/vignettes/annotations.Rmd
+++ b/vignettes/annotations.Rmd
@@ -111,8 +111,8 @@ airway
 We first use `edgeR::filterByExpr()` to remove genes whose counts are too low to
 support a rigorous differential expression analysis. Then we run a standard 
 Limma-Voom analysis using `edgeR::voomLmFit()`, `limma::makeContrasts()`, and
-`limma::eBayes()` (alternatively, we could have used `limma::treat()` instead
-of `limma::eBayes()`).
+`limma::eBayes()`; alternatively, we could have used `limma::treat()` instead
+of `limma::eBayes()`.
 
 The linear model includes the `dex` and `cell` covariates, indicating the
 treatment conditions and cell types, respectively. Here, we are interested in 

--- a/vignettes/iSEEde.Rmd
+++ b/vignettes/iSEEde.Rmd
@@ -66,8 +66,8 @@ packages. `R` can be installed on any operating system from
 
 ```{r "install", eval = FALSE}
 if (!requireNamespace("BiocManager", quietly = TRUE)) {
-      install.packages("BiocManager")
-  }
+    install.packages("BiocManager")
+}
 
 BiocManager::install("iSEEde")
 
@@ -141,17 +141,17 @@ airway <- embedResults(res_deseq2, airway, name = "DESeq2")
 rowData(airway)
 
 app <- iSEE(airway, initial = list(
-  VolcanoPlot(ContrastName="dextrt vs dexuntrt", PanelWidth = 6L),
-  MAPlot(ContrastName="dextrt vs dexuntrt", PanelWidth = 6L)
+    VolcanoPlot(ContrastName = "dextrt vs dexuntrt", PanelWidth = 6L),
+    MAPlot(ContrastName = "dextrt vs dexuntrt", PanelWidth = 6L)
 ))
 
 if (interactive()) {
-  shiny::runApp(app)
+    shiny::runApp(app)
 }
 ```
 
 ```{r, echo=FALSE, out.width="100%"}
-SCREENSHOT("screenshots/landing_page.png", delay=20)
+SCREENSHOT("screenshots/landing_page.png", delay = 20)
 ```
 
 # Reproducibility

--- a/vignettes/iSEEde.Rmd
+++ b/vignettes/iSEEde.Rmd
@@ -57,7 +57,12 @@ bib <- c(
 
 ## Install `iSEEde`
 
-`R` is an open-source statistical environment which can be easily modified to enhance its functionality via packages. `r Biocpkg("iSEEde")` is a `R` package available via the [Bioconductor](http://bioconductor.org) repository for packages. `R` can be installed on any operating system from [CRAN](https://cran.r-project.org/) after which you can install `r Biocpkg("iSEEde")` by using the following commands in your `R` session:
+`R` is an open-source statistical environment which can be easily modified to
+enhance its functionality via packages. `r Biocpkg("iSEEde")` is a `R` package
+available via the [Bioconductor](http://bioconductor.org) repository for
+packages. `R` can be installed on any operating system from
+[CRAN](https://cran.r-project.org/) after which you can install 
+`r Biocpkg("iSEEde")` by using the following commands in your `R` session:
 
 ```{r "install", eval = FALSE}
 if (!requireNamespace("BiocManager", quietly = TRUE)) {
@@ -72,18 +77,39 @@ BiocManager::valid()
 
 ## Required knowledge
 
-`r Biocpkg("iSEEindex")` is based on many other packages and in particular in those that have implemented the infrastructure needed for dealing with omics data and interactive visualisation.
-That is, packages like `r BiocStyle::Biocpkg("SummarizedExperiment")`, `r BiocStyle::Biocpkg("SingleCellExperiment")`, `r BiocStyle::Biocpkg("iSEE")` and `r BiocStyle::Biocpkg("shiny")`.
+`r Biocpkg("iSEEindex")` is based on many other packages and in particular on
+those that have implemented the infrastructure needed for dealing with omics 
+data and interactive visualisation.
+That is, packages like `r BiocStyle::Biocpkg("SummarizedExperiment")`, 
+`r BiocStyle::Biocpkg("SingleCellExperiment")`, `r BiocStyle::Biocpkg("iSEE")` 
+and `r BiocStyle::Biocpkg("shiny")`.
 
-If you are asking yourself the question "Where do I start using Bioconductor?" you might be interested in [this blog post](http://lcolladotor.github.io/2014/10/16/startbioc/#.VkOKbq6rRuU).
+If you are asking yourself the question "Where do I start using Bioconductor?" 
+you might be interested in 
+[this blog post](http://lcolladotor.github.io/2014/10/16/startbioc/#.VkOKbq6rRuU).
 
 ## Asking for help
 
-As package developers, we try to explain clearly how to use our packages and in which order to use the functions. But `R` and `Bioconductor` have a steep learning curve so it is critical to learn where to ask for help. The blog post quoted above mentions some but we would like to highlight the [Bioconductor support site](https://support.bioconductor.org/) as the main resource for getting help: remember to use the `iSEEde` tag and check [the older posts](https://support.bioconductor.org/t/iSEEde/). Other alternatives are available such as creating GitHub issues and tweeting. However, please note that if you want to receive help you should adhere to the [posting guidelines](http://www.bioconductor.org/help/support/posting-guide/). It is particularly critical that you provide a small reproducible example and your session information so package developers can track down the source of the error.
+As package developers, we try to explain clearly how to use our packages and in
+which order to use the functions. But `R` and `Bioconductor` have a steep
+learning curve so it is critical to learn where to ask for help. The blog post
+quoted above mentions some but we would like to highlight the 
+[Bioconductor support site](https://support.bioconductor.org/) 
+as the main resource for getting help: remember to use the `iSEEde` tag and 
+check
+[the older posts](https://support.bioconductor.org/t/iSEEde/). 
+Other alternatives are available such as creating GitHub issues and tweeting. 
+However, please note that if you want to receive help you should adhere to the 
+[posting guidelines](http://www.bioconductor.org/help/support/posting-guide/). 
+It is particularly critical that you provide a small reproducible example and 
+your session information so package developers can track down the source of the
+error.
 
 ## Citing `iSEEde`
 
-We hope that `r Biocpkg("iSEEde")` will be useful for your research. Please use the following information to cite the package and the overall approach. Thank you!
+We hope that `r Biocpkg("iSEEde")` will be useful for your research. Please use
+the following information to cite the package and the overall approach. Thank
+you!
 
 ```{r "citation"}
 ## Citation info
@@ -130,7 +156,8 @@ SCREENSHOT("screenshots/landing_page.png", delay=20)
 
 # Reproducibility
 
-The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible thanks to:
+The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible 
+thanks to:
 
 * R `r Citep(bib[["R"]])`
 * `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
@@ -180,11 +207,12 @@ session_info()
 ```
 
 
-
 # Bibliography
 
-This vignette was generated using `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
-with `r CRANpkg("knitr")` `r Citep(bib[["knitr"]])` and `r CRANpkg("rmarkdown")` `r Citep(bib[["rmarkdown"]])` running behind the scenes.
+This vignette was generated using `r Biocpkg("BiocStyle")` 
+`r Citep(bib[["BiocStyle"]])` with `r CRANpkg("knitr")` 
+`r Citep(bib[["knitr"]])` and `r CRANpkg("rmarkdown")` 
+`r Citep(bib[["rmarkdown"]])` running behind the scenes.
 
 Citations made with `r CRANpkg("RefManageR")` `r Citep(bib[["RefManageR"]])`.
 

--- a/vignettes/methods.Rmd
+++ b/vignettes/methods.Rmd
@@ -57,22 +57,30 @@ bib <- c(
 
 ## Formats
 
-Differential expression results are generally reported as tables of statistics, including (log) fold-change, p-value, average expression, etc.
+Differential expression results are generally reported as tables of statistics,
+including (log) fold-change, p-value, average expression, etc.
 
-Those statistics being reported for individual features (e.g., genes), the `rowData()` component of `SummarizedExperiment()` objects provides a natural home for that information.
-Specifically, `r BiocStyle::Biocpkg("iSEEde")` searches for differential expression results in `rowData(se)[["iSEEde"]]`.
+Those statistics being reported for individual features (e.g., genes), the
+`rowData()` component of `SummarizedExperiment()` objects provides a natural
+home for that information. Specifically, `r BiocStyle::Biocpkg("iSEEde")`
+searches for differential expression results in `rowData(se)[["iSEEde"]]`.
 
-The first challenge arises when differential expression statistics are computed only for a subset of features.
-In that case, `r BiocStyle::Biocpkg("iSEEde")` populates missing information with `NA`.
+The first challenge arises when differential expression statistics are computed
+only for a subset of features. In that case, `r BiocStyle::Biocpkg("iSEEde")`
+populates missing information with `NA`.
 
-The second challenge arises from the different names of columns used by individual differential expression methods to store differential expression common statistics.
-To address this, `r BiocStyle::Biocpkg("iSEEde")` provides S4 classes creating a common interface to supported differential expression methods.
+The second challenge arises from the different names of columns used by
+individual differential expression methods to store differential expression
+common statistics. To address this, `r BiocStyle::Biocpkg("iSEEde")` provides S4
+classes creating a common interface to supported differential expression
+methods.
 
 # Example data
 
 We use the `?airway` data set.
 
-We briefly adjust the reference level of the treatment factor to the untreated condition.
+We briefly adjust the reference level of the treatment factor to the untreated 
+condition.
 
 ```{r, message=FALSE, warning=FALSE}
 library("airway")
@@ -84,35 +92,46 @@ airway$dex <- relevel(airway$dex, "untrt")
 
 ## Limma
 
-We run a standard Limma-Voom analysis using `limma::voom()`, `limma::lmFit()`, `limma::makeContrasts()`, and `limma::eBayes()`.
+We first use `edgeR::filterByExpr()` to remove genes whose counts are too low to
+support a rigorous differential expression analysis. Then we run a standard 
+Limma-Voom analysis using `edgeR::voomLmFit()`, `limma::makeContrasts()`, and
+`limma::eBayes()`.  (Alternatively, we could have used `limma::treat()` instead
+of `limma::eBayes()`.)
 
-Before that though, we use `edgeR::filterByExpr()` to filter genes by expression level.
+The linear model includes the `dex` and `cell` covariates, indicating the
+treatment conditions and cell types, respectively. Here, we are interested in 
+differences between treatments, adjusted by cell type, and define this
+comparison as the `dextrt - dexuntrt` contrast.
 
-The differential expression results are fetched using `limma::topTable()`.
+The final differential expression results are fetched using `limma::topTable()`.
 
 ```{r, message=FALSE, warning=FALSE}
 library("edgeR")
 
-counts <- assay(airway, "counts")
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
-keep <- filterByExpr(counts, design)
-v <- voom(counts[keep,], design, plot=FALSE)
-fit <- lmFit(v, design)
-contr <- makeContrasts("dextrt - dexuntrt", levels = colnames(coef(fit)))
-tmp <- contrasts.fit(fit, contr)
-tmp <- eBayes(tmp)
-res_limma <- topTable(tmp, sort.by = "P", n = Inf)
+keep <- filterByExpr(airway, design)
+fit <- voomLmFit(airway[keep,], design, plot=FALSE)
+contr <- makeContrasts("dextrt - dexuntrt", levels = design)
+fit <- contrasts.fit(fit, contr)
+fit <- eBayes(fit)
+res_limma <- topTable(fit, sort.by = "P", n = Inf)
 head(res_limma)
 ```
 
-Then, we embed this set of differential expression results in the `airway` object using the `embedResults()` method.
+Then, we embed this set of differential expression results in the `airway`
+object using the `embedResults()` method. 
 
-Because the output of `limma::topTable()` is a standard `data.frame`, the `class=` argument must be used to manually identify the method that produced those results.
+Because the output of `limma::topTable()` is a standard `data.frame`, the
+`class=` argument must be used to manually identify the method that produced
+those results.
 
-This manual method is preferable to any automated heuristic, e.g. using the column names of the `data.frame` for identifying it as a `limma::topTable()` output.
+This manual method is preferable to any automated heuristic, e.g. using the
+column names of the `data.frame` for identifying it as a `limma::topTable()`
+output.
 
-The results are nested as a `DataFrame`-like object in `rowData(airway)[["iSEEde"]]`.
+The results are nested as a `DataFrame`-like object in 
+`rowData(airway)[["iSEEde"]]`.
 
 ```{r}
 library(iSEEde)
@@ -122,9 +141,9 @@ rowData(airway)
 
 ## DESeq2
 
-We run a standard `r BiocStyle::Biocpkg("DESeq2")` analysis using `DESeq()`.
-
-Before that though, we use `DESeqDataSet()` to construct a `DESeqDataSet` object for the analysis.
+First, we use `DESeqDataSet()` to construct a `DESeqDataSet` object
+for the analysis. Then we run a standard `r BiocStyle::Biocpkg("DESeq2")`
+analysis using `DESeq()`.
 
 The differential expression results are fetched using `results()`.
 
@@ -138,11 +157,15 @@ res_deseq2 <- results(dds, contrast = list("dextrt", "dexuntrt"))
 head(res_deseq2)
 ```
 
-Then, we embed this set of differential expression results in the `airway` object using the `embedResults()` method.
+Then, we embed this set of differential expression results in the `airway` 
+object using the `embedResults()` method.
 
-In this instance, the `r BiocStyle::Biocpkg("DESeq2")` results are stored in a recognisable `?DESeqResults` object.
-As such, the results object can be given *as is* directly to the `embedResults()` method.
-The function will automatically pass the results object to the `iSEEDESeq2Results()` constructor, to identify it as such.
+In this instance, the `r BiocStyle::Biocpkg("DESeq2")` results are stored in a
+recognisable `?DESeqResults` object, which can be given *as is* directly to the
+`embedResults()` method.
+
+The function will automatically pass the results object to the 
+`iSEEDESeq2Results()` constructor, to identify it as such.
 
 ```{r}
 airway <- embedResults(res_deseq2, airway, name = "DESeq2")
@@ -151,27 +174,30 @@ rowData(airway)
 
 ## edgeR
 
-We run a standard `r BiocStyle::Biocpkg("edgeR")` analysis using `glmFit()` and `glmLRT()`.
+We run a standard `r BiocStyle::Biocpkg("edgeR")` analysis using `glmFit()` and
+`glmLRT()`.
 
 The differential expression results are fetched using `topTags()`.
 
 ```{r, message=FALSE, warning=FALSE}
 library("edgeR")
 
-counts <- assay(airway, "counts")
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
-fit <- glmFit(counts, design, dispersion=0.1)
+fit <- glmFit(airway, design, dispersion=0.1)
 lrt <- glmLRT(fit, contrast = c(-1, 1, 0, 0, 0))
 res_edger <- topTags(lrt, n = Inf)
 head(res_edger)
 ```
 
-Then, we embed this set of differential expression results in the `airway` object using the `embedResults()` method.
+Then, we embed this set of differential expression results in the `airway`
+object using the `embedResults()` method.
 
-In this instance, the `r BiocStyle::Biocpkg("edgeR")` results are stored in a recognisable `?TopTags` object.
-As such, the results object can be given *as is* directly to the `embedResults()` method.
-The function will automatically pass the results object to the `iSEEedgeRResults()` constructor, to identify it as such.
+In this instance, the `r BiocStyle::Biocpkg("edgeR")` results are stored in a 
+recognisable `?TopTags` object. As such, the results object can be given *as is*
+directly to the `embedResults()` method. The function will automatically pass
+the results object to the `iSEEedgeRResults()` constructor, to identify it as
+such.
 
 ```{r}
 airway <- embedResults(res_edger, airway, name = "edgeR")
@@ -202,7 +228,8 @@ SCREENSHOT("screenshots/volcano_plots.png", delay=20)
 
 # Reproducibility
 
-The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible thanks to:
+The `r Biocpkg("iSEEde")` package `r Citep(bib[["iSEEde"]])` was made possible
+thanks to:
 
 * R `r Citep(bib[["R"]])`
 * `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
@@ -255,8 +282,10 @@ session_info()
 
 # Bibliography
 
-This vignette was generated using `r Biocpkg("BiocStyle")` `r Citep(bib[["BiocStyle"]])`
-with `r CRANpkg("knitr")` `r Citep(bib[["knitr"]])` and `r CRANpkg("rmarkdown")` `r Citep(bib[["rmarkdown"]])` running behind the scenes.
+This vignette was generated using `r Biocpkg("BiocStyle")` `r
+Citep(bib[["BiocStyle"]])` with `r CRANpkg("knitr")` `r Citep(bib[["knitr"]])`
+and `r CRANpkg("rmarkdown")` `r Citep(bib[["rmarkdown"]])` running behind the
+scenes.
 
 Citations made with `r CRANpkg("RefManageR")` `r Citep(bib[["RefManageR"]])`.
 

--- a/vignettes/methods.Rmd
+++ b/vignettes/methods.Rmd
@@ -111,7 +111,7 @@ library("edgeR")
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
 keep <- filterByExpr(airway, design)
-fit <- voomLmFit(airway[keep,], design, plot=FALSE)
+fit <- voomLmFit(airway[keep, ], design, plot = FALSE)
 contr <- makeContrasts("dextrt - dexuntrt", levels = design)
 fit <- contrasts.fit(fit, contr)
 fit <- eBayes(fit)
@@ -184,7 +184,7 @@ library("edgeR")
 
 design <- model.matrix(~ 0 + dex + cell, data = colData(airway))
 
-fit <- glmFit(airway, design, dispersion=0.1)
+fit <- glmFit(airway, design, dispersion = 0.1)
 lrt <- glmLRT(fit, contrast = c(-1, 1, 0, 0, 0))
 res_edger <- topTags(lrt, n = Inf)
 head(res_edger)
@@ -209,21 +209,21 @@ rowData(airway)
 ```{r}
 library(iSEE)
 app <- iSEE(airway, initial = list(
-  VolcanoPlot(ContrastName="Limma-Voom", PanelWidth = 6L),
-  MAPlot(ContrastName="Limma-Voom", PanelWidth = 6L),
-  VolcanoPlot(ContrastName="DESeq2", PanelWidth = 6L),
-  MAPlot(ContrastName="DESeq2", PanelWidth = 6L),
-  VolcanoPlot(ContrastName="edgeR", PanelWidth = 6L),
-  MAPlot(ContrastName="edgeR", PanelWidth = 6L)
+    VolcanoPlot(ContrastName = "Limma-Voom", PanelWidth = 6L),
+    MAPlot(ContrastName = "Limma-Voom", PanelWidth = 6L),
+    VolcanoPlot(ContrastName = "DESeq2", PanelWidth = 6L),
+    MAPlot(ContrastName = "DESeq2", PanelWidth = 6L),
+    VolcanoPlot(ContrastName = "edgeR", PanelWidth = 6L),
+    MAPlot(ContrastName = "edgeR", PanelWidth = 6L)
 ))
 
 if (interactive()) {
-  shiny::runApp(app)
+    shiny::runApp(app)
 }
 ```
 
 ```{r, echo=FALSE, out.width="100%"}
-SCREENSHOT("screenshots/volcano_plots.png", delay=20)
+SCREENSHOT("screenshots/volcano_plots.png", delay = 20)
 ```
 
 # Reproducibility


### PR DESCRIPTION
- Suggested the use `edgeR::voomLmFit()` instead of separate `voom()` and `lmFit` calls 
  in the `methods.Rmd` vignette. 
- The `glmFit`, `filterByExpr` and `voomLmFit()` function accept a SummarizedExperiment
  as input, simplifying the analysis code.
- I added a short explanation of the contrast extracted in the limma-voom example.
- limma offers two ways of calculating moderated p-values, t-stats, etc: `eBayes` and 
  `treat`. `treat` performs a test relative to a minimum fold-change threshold. The output
  from both calculations is extracted with the `topTable()` function and is almost
  identical except for `treat()` not returning the `B` column. It's already supported by
  the `iSEELimmaResults` class, but I added a sentence pointing out this alternative path
  in the `methods.Rmd` vignette.
- Replaced `scater` with `scuttle` as a suggested dependency (just because that's where
  the `uniquifyFeatureNames` function is actually defined).
- Wrapped text lines in the Rmd vignettes, and fixed a few typos.
